### PR TITLE
index: export `core_hsalsa20` and `SIGMA`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ module.exports = XSalsa20
 XSalsa20.NONCEBYTES = 24
 XSalsa20.KEYBYTES = 32
 
+XSalsa20.core_hsalsa20 = core_hsalsa20
+XSalsa20.SIGMA = SIGMA
+
 function XSalsa20 (nonce, key) {
   if (!(this instanceof XSalsa20)) return new XSalsa20(nonce, key)
   if (!nonce || nonce.length < 24) throw new Error('nonce must be at least 24 bytes')

--- a/test.js
+++ b/test.js
@@ -160,3 +160,19 @@ tape('encrypt and decrypt', function (t) {
   t.same(cipher, message, 'unencrypted')
   t.end()
 })
+
+tape('core_hsalsa20', function (t) {
+  var input = new Buffer(
+    '50824531b103669bb974a92e03e27289e09ef7328b8c22bf3267c811bf28477c', 'hex')
+  var output = new Buffer(32)
+  var zero = new Buffer(16)
+  zero.fill(0)
+
+  xsalsa20.core_hsalsa20(output, zero, input, xsalsa20.SIGMA)
+
+  var expected = new Buffer(
+    '44317f32de851b34393a990b004840dc6e468fe10302ba4ec15b3304df34e326', 'hex')
+  t.same(output, expected, 'core_hsalsa20 output')
+
+  t.end()
+});


### PR DESCRIPTION
`core_hsalsa20` and `SIGMA` are required for implementing
`crypto_box_seal`/`crypto_box_seal_open` in `sodium-javascript`.