### PR TITLE
Fix `Buffer()` deprecation warning

### DIFF
--- a/xsalsa20.js
+++ b/xsalsa20.js
@@ -53,7 +53,7 @@ function loadWebAssembly (opts) {
 
 function toUint8Array (s) {
   if (typeof atob === 'function') return new Uint8Array(atob(s).split('').map(charCodeAt))
-  return new (require('buf' + 'fer').Buffer)(s, 'base64')
+  return require('buf' + 'fer').Buffer.from(s, 'base64')
 }
 
 function charCodeAt (c) {


### PR DESCRIPTION
In recent node versions you get the following warning when using the `Buffer()` constructor:

> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

See also the [API reference](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding) and [documentation on this issue](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/).

(BTW I would also question the `require('buf' + 'fer')` construct but left it as-is for now.)